### PR TITLE
Use default port for memcached instances

### DIFF
--- a/template/mcrouter-config.tpl
+++ b/template/mcrouter-config.tpl
@@ -2,7 +2,7 @@
   "pools": {
     "default": {
       "servers": [ {{if .servers}}
-        {{ range $key, $value := .servers }}"{{$value}}:5000",{{end}}
+        {{ range $key, $value := .servers }}"{{$value}}:11211",{{end}}
     {{end}}]
     }
   },


### PR DESCRIPTION
The default port on memcached is `11211`. Fixing this template will allow the example to work without issue.